### PR TITLE
Composer: add installer-name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,5 +14,8 @@
 	"require":
 	{
 		"silverstripe/framework": "3.*"
+	},
+	"extra": {
+		"installer-name": "email-helpers"
 	}
 }


### PR DESCRIPTION
So it doesn't add silverstripe to module name.
