### PR TITLE
Composer: replace old name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,5 +17,8 @@
 	},
 	"extra": {
 		"installer-name": "email-helpers"
-	}
+	},
+	"replace": {
+    		"markguinn/silverstripe-email-helpers": "*"
+    	}
 }


### PR DESCRIPTION
This command should replace the name of the module of who have already installed it as "silverstripe-email-helpers".
