### PR TITLE
isSMTP not IsSMTP is the method in the PHPMailer class

### DIFF
--- a/code/SmtpMailer.php
+++ b/code/SmtpMailer.php
@@ -136,7 +136,7 @@ class SmtpMailer extends Mailer
     protected function initMailer()
     {
         $mail = new PHPMailer();
-        $mail->IsSMTP();
+        $mail->isSMTP();
         $mail->Host = $this->host;
 
         if ($this->user) {


### PR DESCRIPTION
isSMTP not IsSMTP (capital 'I') is the method in the PHPMailer class. Please see link below:
https://github.com/PHPMailer/PHPMailer/search?l=php&q=IsSMTP&utf8=✓
Thanks