### PR TITLE
Inline CSS by default

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+/tests export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.travis.yml export-ignore
+/phpunit.xml export-ignore

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+# See https://github.com/silverstripe-labs/silverstripe-travis-support for setup details
+# used Silverstripe Translatable as a guide
+
+language: php
+php:
+ - 5.4
+
+sudo: false
+
+env:
+ - DB=MYSQL CORE_RELEASE=3.3 PDO=1
+
+matrix:
+  include:
+   - php: 5.5
+     env: DB=PGSQL CORE_RELEASE=3.2
+
+before_script:
+ - phpenv rehash
+ - git clone git://github.com/silverstripe-labs/silverstripe-travis-support.git ~/travis-support
+ - php ~/travis-support/travis_setup.php --source `pwd` --target ~/builds/ss
+ - cd ~/builds/ss
+
+script:
+# Execute tests
+ - vendor/bin/phpunit email-helpers/tests/

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ SilverStripe Email Helpers
 Contains replacement Mailer object that utilizes PHPMailer to send
 e-mail via SMTP instead of php's mail() function.  Optionally, TLS can
 be enabled for secure communication with the SMTP server and a charset
-for the e-mail encoding can be specified.  Any embedded CSS, and a specified 
-external CSS file, are inlined into the HTML. 
+for the e-mail encoding can be specified.  In addition, embedded CSS, plus a specified 
+external CSS file, can be inlined into the email's HTML.
 
 Also includes a drop-in replacement for the Email class called
 StyledHtmlEmail.  If used with HTML emails it allows you to include a style
@@ -30,19 +30,15 @@ This module installs PHPMailer and Emogrifier:
  - https://github.com/jjriv/emogrifier
 
 ## Usage
-To use the SMTP mailer at the following code to your _config.php:
+### SMTP Mailer
+To use the SMTP mailer add the following code to your _config.php:
 
 ```php
 $tls = true;        // use tls authentication if true
 $charset = 'UTF-8'; // use specified charset if set
 // you can specify a port as in 'yourserver.com:587'
 $mailer = new SmtpMailer('yourserver.com', 'username', 'password', $tls, $charset);
-Email::set_mailer($mailer);
-```
-And optionally, to inline CSS from an external file:
-```
-SmtpMailer:
-  cssfile: 'themes/{yourtheme}/css/externalcssfile.css'
+Email::set_mailer($mailer);  // or Injector::inst()->registerService($mailer, 'Mailer');
 ```
 
 Alternatively, any of these can be set using the config system like so:
@@ -54,15 +50,46 @@ SmtpMailer:
   password: password
   tls: true
   charset: UTF-8
-  cssfile: 'themes/{yourtheme}/css/externalcssfile.css'
 ```
-
 And then:
 
 ```
-Email::set_mailer( new SmtpMailer() );
+Email::set_mailer( new SmtpMailer() );  // or Injector::inst()->registerService($mailer, 'Mailer');
 ```
 
+### Emogrified Smtp Mailer
+If you wish to embed CSS into your email's HTML then use the `EmogrifiedSmtpMailer` class.  Add the following code to your _config.php:
+
+```php
+$tls = true;
+$charset = 'UTF-8';
+$externalcssfile = 'themes/{yourtheme}/css/externalcssfile.css';  // specify the path to your css file
+$SMTPDebug = 2;  // Levels 0-4 available
+$logfailedemail = true;  // Log a notice with PHPMailer's error information
+$mailer = new EmogrifiedSmtpMailer('yourserver.com', 'username', 'password', $tls, $charset, $externalcssfile, $SMTPDebug, $logfailedemail);
+Email::set_mailer($mailer);  // or Injector::inst()->registerService($mailer, 'Mailer');
+```
+
+Alternatively, any of these can be set using the config system like so:
+
+```
+EmogrifiedSmtpMailer:
+  host: yourserver.com
+  user: username
+  password: password
+  tls: true
+  charset: UTF-8
+  cssfile: 'themes/{yourtheme}/css/externalcssfile.css'
+  SMTPDedug: 2
+  logfailedemail: true
+```
+And then:
+
+```
+Email::set_mailer( new SmtpMailer() );  // or Injector::inst()->registerService($mailer, 'Mailer');
+```
+
+### Styled Html Email
 To use the styled email, just literally use the StyledHtmlEmail class where you'd normally use the Email class
 and add a single style tag in the body of the email. For example:
 

--- a/README.md
+++ b/README.md
@@ -51,10 +51,10 @@ SmtpMailer:
   tls: true
   charset: UTF-8
 ```
-And then:
+And then in _config.php:
 
-```
-Email::set_mailer( new SmtpMailer() );  // or Injector::inst()->registerService($mailer, 'Mailer');
+```php
+Email::set_mailer( new SmtpMailer() );
 ```
 
 ### Emogrified Smtp Mailer
@@ -83,10 +83,10 @@ EmogrifiedSmtpMailer:
   SMTPDedug: 2
   logfailedemail: true
 ```
-And then:
+And then in _config.php:
 
-```
-Email::set_mailer( new SmtpMailer() );  // or Injector::inst()->registerService($mailer, 'Mailer');
+```php
+Email::set_mailer( new EmogrifiedSmtpMailer() );
 ```
 
 ### Styled Html Email

--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
 SilverStripe Email Helpers
 ==========================
 
+[![Build Status](https://travis-ci.org/markguinn/silverstripe-email-helpers.svg)](https://travis-ci.org/markguinn/silverstripe-email-helpers)
+
 Contains replacement Mailer object that utilizes PHPMailer to send
 e-mail via SMTP instead of php's mail() function.  Optionally, TLS can
 be enabled for secure communication with the SMTP server and a charset
-for the e-mail encoding can be specified.
+for the e-mail encoding can be specified.  Any embedded CSS, and a specified 
+external CSS file, are inlined into the HTML. 
 
 Also includes a drop-in replacement for the Email class called
 StyledHtmlEmail.  If used with HTML emails it allows you to include a style
@@ -22,15 +25,9 @@ Install via composer:
 composer require markguinn/silverstripe-email-helpers:dev-master
 ```
 
-This module now uses composer to install PHPMailer and Emogrifier. If installing
-manually, you will need to install those two dependencies and make sure they are
-autoloaded or required somehow (composer does this automatically). You can find
-them on github here:
-
+This module installs PHPMailer and Emogrifier:
  - https://github.com/PHPMailer/PHPMailer
  - https://github.com/jjriv/emogrifier
-
-(but really you should learn how to use composer)
 
 ## Usage
 To use the SMTP mailer at the following code to your _config.php:
@@ -42,6 +39,11 @@ $charset = 'UTF-8'; // use specified charset if set
 $mailer = new SmtpMailer('yourserver.com', 'username', 'password', $tls, $charset);
 Email::set_mailer($mailer);
 ```
+And optionally, to inline CSS from an external file:
+```
+SmtpMailer:
+  cssfile: 'themes/{yourtheme}/css/externalcssfile.css'
+```
 
 Alternatively, any of these can be set using the config system like so:
 
@@ -52,6 +54,7 @@ SmtpMailer:
   password: password
   tls: true
   charset: UTF-8
+  cssfile: 'themes/{yourtheme}/css/externalcssfile.css'
 ```
 
 And then:

--- a/code/EmogrifiedSmtpMailer.php
+++ b/code/EmogrifiedSmtpMailer.php
@@ -1,0 +1,180 @@
+<?php
+/**
+ * This is a simple extension of the built in SS email class
+ * that uses the PHPMailer library to send emails via SMTP and Emogifier to inline CSS.
+ *
+ * Usage: (in mysite/_config.php)
+ *
+ * @example  $mailer = new EmogrifiedSmtpMailer('mail.server.com', 'username', 'password', true, 'UTF-8');
+ * Email::set_mailer($mailer);
+ * @package smtpmailer
+ */
+class EmogrifiedSmtpMailer extends SmtpMailer
+{
+    /**
+     * CSS file containing classes to inline into the email's HTML
+     *
+     * @var string $cssfile path to css file from project root
+     */
+    protected $cssfile;
+
+    /**
+     * PHPMailer SMTPDebug setting
+     *
+     * `0` No output
+     * `1` Commands
+     * `2` Data and commands
+     * `3` As 2 plus connection status
+     * `4` Low-level data output
+     * @var integer $SMTPDebug
+     */
+    protected $SMTPDebug = 0;
+
+    /**
+     * Log failed emails
+     *
+     * @var bool $logfailedemail
+     */
+    protected $logfailedemail = false;
+
+    /**
+     * creates and configures the mailer
+     */
+    public function __construct($host=false, $user=false, $pass=false, $tls='fallback', $charset=false, $cssfile=false, $SMTPDebug='fallback', $logfailedemail=false)
+    {
+        if ($host === false) {
+            $host = Config::inst()->get('EmogrifiedSmtpMailer', 'host');
+        }
+        if ($user === false) {
+            $user = Config::inst()->get('EmogrifiedSmtpMailer', 'user');
+        }
+        if ($pass === false) {
+            $pass = Config::inst()->get('EmogrifiedSmtpMailer', 'password');
+        }
+        if ($tls === 'fallback') {
+            $tls = Config::inst()->get('EmogrifiedSmtpMailer', 'tls');
+        }
+        if ($charset === false) {
+            $charset = Config::inst()->get('EmogrifiedSmtpMailer', 'charset');
+        }
+        if ($cssfile === false) {
+            $cssfile = Config::inst()->get('EmogrifiedSmtpMailer', 'cssfile');
+        }
+        if ($SMTPDebug === 'fallback') {
+            $SMTPDebug = Config::inst()->get('EmogrifiedSmtpMailer', 'SMTPDebug');
+        }
+        if ($logfailedemail === false) {
+            $logfailedemail = Config::inst()->get('EmogrifiedSmtpMailer', 'logfailedemail');
+        }
+
+        $this->setHost($host);
+        $this->setCredentials($user, $pass);
+        $this->setTls($tls);
+        $this->setCharset($charset);
+        $this->setCSSfile($cssfile);
+        if ($SMTPDebug) {
+            $this->setSMTPDebug($SMTPDebug);
+        }
+        $this->setLogfailedemail($logfailedemail);
+    }
+
+    /**
+     * @return string
+     */
+    public function getCSSfile()
+    {
+        return $this->cssfile;
+    }
+
+    /**
+     * @param integer $cssfile
+     * @return $this
+     */
+    public function setCSSfile($cssfile)
+    {
+        $this->cssfile = (string)$cssfile;
+        return $this;
+    }
+
+    /**
+     * @return integer
+     */
+    public function getSMTPDebug()
+    {
+        return $this->SMTPDebug;
+    }
+
+    /**
+     * @param integer $input PHPMailer SMTPDebug setting
+     * @return $this
+     */
+    public function setSMTPDebug($input)
+    {
+        if ($input == 0 || $input == 1 || $input == 2 || $input == 3 || $input == 4) {
+            $this->SMTPDebug = (int)$input;
+        } else {
+            user_error("PHPMailer SMTPDebug setting needs to be an integer from 0-4", E_USER_WARNING);
+        }
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLogfailedemail()
+    {
+        return $this->logfailedemail;
+    }
+
+    /**
+     * @param integer $logfailedemail
+     * @return $this
+     */
+    public function setLogfailedemail($logfailedemail)
+    {
+        $this->logfailedemail = (bool)$logfailedemail;
+        return $this;
+    }
+
+    /**
+     * Send a multi-part HTML email with inlined CSS
+     *
+     * @param string $to
+     * @param string $from
+     * @param string $subject
+     * @param string $htmlContent
+     * @param array|bool $attachedFiles
+     * @param array|bool $customheaders
+     * @param bool $plainContent
+     * @param bool $inlineImages
+     *
+     * @return bool
+     */
+    public function sendHTML($to, $from, $subject, $htmlContent, $attachedFiles = false, $customheaders = false, $plainContent = false, $inlineImages = false)
+    {
+        $mail = $this->initEmail($to, $from, $subject, $attachedFiles, $customheaders);
+
+        // set up the body
+        // @todo inlineimages
+        $mail->Body = InlineCSS::convert($htmlContent, $this->getCSSfile());
+        $mail->IsHTML(true);
+        if ($plainContent) {
+            $mail->AltBody = $plainContent;
+        }
+        if ($level = $this->getSMTPDebug()) {
+            $mail->SMTPDebug = $level;
+            $mail->Debugoutput = 'html';  // HTML friendly report
+        }
+
+        // send and return
+        if ($mail->Send()) {
+            return array($to, $subject, $mail->Body, $customheaders);
+        } else {
+            if ($this->getLogfailedemail()) {
+                SS_Log::log(new Exception(print_r($mail->ErrorInfo, true)), SS_Log::NOTICE);
+            }
+            return false;
+        }
+    }
+}
+

--- a/code/InlineCSS.php
+++ b/code/InlineCSS.php
@@ -1,0 +1,32 @@
+<?php
+use Pelago\Emogrifier;
+
+/**
+ * Inline CSS
+ */
+class InlineCSS
+{
+    /**
+     * Inline both the embedded css, and css from an external file, into html
+     *
+     * @param  HTML $htmlContent
+     * @param string $cssFile path and filename
+     * @return HTML with inlined CSS
+     */
+    public static function convert($htmlContent, $cssfile)
+    {
+        $emog = new Emogrifier($htmlContent);
+
+        // Apply the css file to Emogrifier
+        if ($cssfile) {
+            $cssFileLocation = join(DIRECTORY_SEPARATOR, array(Director::baseFolder(), $cssfile));
+            $cssFileHandler = fopen($cssFileLocation, 'r');
+            $css = fread($cssFileHandler, filesize($cssFileLocation));
+            fclose($cssFileHandler);
+
+            $emog->setCss($css);
+        }
+
+        return $emog->emogrify();
+    }
+}

--- a/code/SmtpMailer.php
+++ b/code/SmtpMailer.php
@@ -15,6 +15,13 @@
 class SmtpMailer extends Mailer
 {
     /**
+     * CSS file to inline into HTML
+     *
+     * @var string $cssfile path to css file from project root
+     */
+    private static $cssfile = '';
+    
+    /**
      * @var string $host - smtp host
      */
     protected $host;
@@ -283,7 +290,7 @@ class SmtpMailer extends Mailer
 
 
     /**
-     * Send a multi-part HTML email.
+     * Send a multi-part HTML email with inlined CSS
      *
      * @param string $to
      * @param string $from
@@ -299,18 +306,19 @@ class SmtpMailer extends Mailer
     public function sendHTML($to, $from, $subject, $htmlContent, $attachedFiles = false, $customheaders = false, $plainContent = false, $inlineImages = false)
     {
         $mail = $this->initEmail($to, $from, $subject, $attachedFiles, $customheaders);
-        
+
         // set up the body
         // @todo inlineimages
+        $mail->Body = InlineCSS::convert($htmlContent, self::$cssfile);
         $mail->IsHTML(true);
-        $mail->Body = $htmlContent;
+
         if ($plainContent) {
             $mail->AltBody = $plainContent;
         }
-        
+
         // send and return
         if ($mail->Send()) {
-            return array($to,$subject,$htmlContent,$customheaders);
+            return array($to, $subject, $mail->Body, $customheaders);
         } else {
             return false;
         }

--- a/code/SmtpMailer.php
+++ b/code/SmtpMailer.php
@@ -15,13 +15,6 @@
 class SmtpMailer extends Mailer
 {
     /**
-     * CSS file to inline into HTML
-     *
-     * @var string $cssfile path to css file from project root
-     */
-    private static $cssfile = '';
-    
-    /**
      * @var string $host - smtp host
      */
     protected $host;
@@ -290,7 +283,7 @@ class SmtpMailer extends Mailer
 
 
     /**
-     * Send a multi-part HTML email with inlined CSS
+     * Send a multi-part HTML email.
      *
      * @param string $to
      * @param string $from
@@ -306,19 +299,18 @@ class SmtpMailer extends Mailer
     public function sendHTML($to, $from, $subject, $htmlContent, $attachedFiles = false, $customheaders = false, $plainContent = false, $inlineImages = false)
     {
         $mail = $this->initEmail($to, $from, $subject, $attachedFiles, $customheaders);
-
+        
         // set up the body
         // @todo inlineimages
-        $mail->Body = InlineCSS::convert($htmlContent, self::$cssfile);
         $mail->IsHTML(true);
-
+        $mail->Body = $htmlContent;
         if ($plainContent) {
             $mail->AltBody = $plainContent;
         }
-
+        
         // send and return
         if ($mail->Send()) {
-            return array($to, $subject, $mail->Body, $customheaders);
+            return array($to,$subject,$htmlContent,$customheaders);
         } else {
             return false;
         }

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,9 @@
 		"pelago/emogrifier": "dev-master",
 		"phpmailer/phpmailer": "~5.2.8"
 	},
+	"require-dev": {
+		"phpunit/PHPUnit": "3.7.*@stable"
+	},
 	"extra": {
 		"installer-name": "email-helpers",
 		"branch-alias": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,39 @@
+<!-- 
+	PHPUnit configuration for SilverStripe
+
+	Requires PHPUnit 3.5+
+
+	Usage: 
+	 - "phpunit": Runs all tests in all folders
+	 - "phpunit framework/tests/": Run all tests of the framework module
+	 - "phpunit framework/tests/filesystem": Run all filesystem tests within the framework module
+	 - "phpunit framework/tests/filesystem/FolderTest.php": Run a single test
+	 - "phpunit <dash><dash>coverage-html assets/": Generate coverage report (replace <dash> with "-", requires xdebug)
+	
+	More information:
+	- http://www.phpunit.de/manual/current/en/textui.html
+	- http://doc.silverstripe.org/framework/en/topics/testing/#configuration
+-->
+<phpunit bootstrap="../framework/tests/bootstrap.php" colors="true">
+
+	<testsuite name="Default">
+		<directory>tests</directory>
+	</testsuite>
+	
+	<listeners>
+		<listener class="SS_TestListener" file="../framework/dev/TestListener.php" />
+	</listeners>
+	
+	<groups>
+		<exclude>
+			<group>sanitychecks</group>
+		</exclude>
+	</groups>
+
+	<filter>
+		<whitelist processUncoveredFilesFromWhitelist="true">
+			<directory suffix=".php">code</directory>
+		</whitelist>
+	</filter>
+
+</phpunit>

--- a/tests/EmailHelpersTest.php
+++ b/tests/EmailHelpersTest.php
@@ -12,7 +12,8 @@ class EmailHelpersTest extends SapphireTest
     public function testSmtpMailerSetup()
     {
         // PHPMailer setup
-        Injector::inst()->registerService(new SmtpMailer('yourserver.com:587', 'username', 'password', true, 'UTF-8'), 'Mailer');
+        $mailer = new SmtpMailer('yourserver.com:587', 'username', 'password', true, 'UTF-8');
+        Injector::inst()->registerService($mailer, 'Mailer');
 
         $smtpmailer = Email::mailer();
         $this->assertEquals('SmtpMailer', get_class($smtpmailer), "SmtpMailer class is used for sending emails");
@@ -20,9 +21,24 @@ class EmailHelpersTest extends SapphireTest
         $this->assertContains('UTF-8', $smtpmailer->getCharset(), "Charset set to UTF-8 as set in Injector");
     }
 
+    public function testEmogrifiedSmtpMailerSetup()
+    {
+        // PHPMailer setup
+        $mailer = new EmogrifiedSmtpMailer('yourserver.com:587', 'username', 'password', true, 'UTF-8', 'silvershop/css/order.css', 1, true);
+        Injector::inst()->registerService($mailer, 'Mailer');
+
+        $emogrifiedsmtpmailer = Email::mailer();
+        $this->assertEquals('EmogrifiedSmtpMailer', get_class($emogrifiedsmtpmailer), "EmogrifiedSmtpMailer class is used for sending emails");
+        $this->assertTrue($emogrifiedsmtpmailer->getTls(), "tls is set to true as set in Injector");
+        $this->assertSame('UTF-8', $emogrifiedsmtpmailer->getCharset(), "Charset set to UTF-8 as set in Injector");
+        $this->assertSame('silvershop/css/order.css', $emogrifiedsmtpmailer->getCSSfile(), 'The CSS file is set to silvershop/css/order.css');
+        $this->assertSame(1, $emogrifiedsmtpmailer->getSMTPDebug(), 'SMTPDebug is set to 1');
+        $this->assertTrue($emogrifiedsmtpmailer->getLogfailedemail(), "Failed emails to be logged");
+
+    }
+
     public function testInlineCSS()
     {
-
         // Get HTML file from Fixtures
         $fileLocation = join(DIRECTORY_SEPARATOR, array(__DIR__, 'fixtures/testhtml.html'));
         $fileHandler = fopen($fileLocation, 'r');

--- a/tests/EmailHelpersTest.php
+++ b/tests/EmailHelpersTest.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * PHPUnit Tests for Silverstripe Email Helpers
+ *
+ * @package Silverstripe Email Helpers
+ * @subpackage tests
+ */
+class EmailHelpersTest extends SapphireTest
+{
+
+    public function testSmtpMailerSetup()
+    {
+        // PHPMailer setup
+        Injector::inst()->registerService(new SmtpMailer('yourserver.com:587', 'username', 'password', true, 'UTF-8'), 'Mailer');
+
+        $smtpmailer = Email::mailer();
+        $this->assertEquals('SmtpMailer', get_class($smtpmailer), "SmtpMailer class is used for sending emails");
+        $this->assertTrue($smtpmailer->getTls(), "tls is set to true as set in Injector");
+        $this->assertContains('UTF-8', $smtpmailer->getCharset(), "Charset set to UTF-8 as set in Injector");
+    }
+
+    public function testInlineCSS()
+    {
+
+        // Get HTML file from Fixtures
+        $fileLocation = join(DIRECTORY_SEPARATOR, array(__DIR__, 'fixtures/testhtml.html'));
+        $fileHandler = fopen($fileLocation, 'r');
+        $htmlContent = fread($fileHandler, filesize($fileLocation));
+        fclose($fileHandler);
+
+        // Note reference to external css file
+        $inlinedCSS = InlineCSS::convert($htmlContent, 'email-helpers/tests/fixtures/externalcssfile.css');
+
+        $this->assertContains('<body style="font-family: Helvetica,Arial,sans-serif; font-size: 14px; line-height: 1.6em; margin: 0; width: 100% !important; height: 100%;">', $inlinedCSS, 'Body element contains inline styling');
+        $this->assertContains('<table id="Content" cellspacing="0" cellpadding="0" summary="Order Information" style="text-align: left; margin: auto; padding-left: 20px;">', $inlinedCSS, 'Table element contains inline styling');
+        $this->assertContains('<tr class="itemRow" style="background-color: red;">', $inlinedCSS, 'Table row contains inline styling');
+        $this->assertContains('<td class="image" style="border: 1px;"></td>', $inlinedCSS, 'Table cell contains inline styling');
+    }
+}

--- a/tests/fixtures/externalcssfile.css
+++ b/tests/fixtures/externalcssfile.css
@@ -1,0 +1,6 @@
+td.image {
+    border: 1px;
+}
+td.product{
+    background-color: blue;
+}

--- a/tests/fixtures/testhtml.html
+++ b/tests/fixtures/testhtml.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+        <meta name="viewport" content="width=device-width">
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+        <title>Minecraft Shop Order MC00260 (6 February 2016)</title>
+        <style>
+            body{
+                font-family: Helvetica,Arial,sans-serif; font-size: 14px; line-height: 1.6em; margin: 0; width: 100% !important; height: 100%;
+            }
+            table{
+                text-align: left; margin: auto; padding-left: 20px;
+            }
+            .itemRow{
+                background-color: red;
+            }
+            .center{
+                text-align: center;
+            }
+            .right{
+                text-align: right;
+            }
+        </style>
+    </head>
+    <body>
+        <table id="Content" cellspacing="0" cellpadding="0" summary="Order Information">
+            <tbody>
+                <tr class="itemRow">
+                    <td class="image"></td>
+                    <td class="product title" scope="row">
+                        <a href="products/mine-craft/wooden-sword" title="Read more">Wooden Sword</a>
+                    </td>
+                    <td class="center unitprice">$6.00</td>
+                    <td class="center quantity">6</td>
+                    <td class="right total">$36.00</td>
+                </tr>
+            </tbody>
+        </table>
+    </body>
+</html>


### PR DESCRIPTION
It would be a great benefit to inline CSS in HTML emails by default.  This combined with the reliable PHPMailer and your easy configuration will create better looking emails for Silverstripe sites.   

Was inspired by https://github.com/sunnysideup/silverstripe-newsletter_emogrify/blob/master/code/EmogrifierMailer.php and https://github.com/burnbright/silverstripe-inlinestylesemail/blob/master/code/InlineStylesMailer.php both of which inline CSS but without PHPMailer. 

Have tested this pull request on a soon to be launched SS Shop site.

Thanks