### PR TITLE
Updated EmogrifiedSmtpMailer for logging

### DIFF
--- a/code/EmogrifiedSmtpMailer.php
+++ b/code/EmogrifiedSmtpMailer.php
@@ -165,7 +165,7 @@ class EmogrifiedSmtpMailer extends SmtpMailer
             $mail->SMTPDebug = $level;
             $mail->Debugoutput = function ($str, $level)
             {
-                SS_Log::log(new Exception(print_r($str, true)), SS_Log::NOTICE);
+                SS_Log::log(print_r($str, true), SS_Log::NOTICE);
             };
         }
 
@@ -174,7 +174,7 @@ class EmogrifiedSmtpMailer extends SmtpMailer
             return array($to, $subject, $mail->Body, $customheaders);
         } else {
             if ($this->getLogfailedemail()) {
-                SS_Log::log(new Exception(print_r($mail->ErrorInfo, true)), SS_Log::NOTICE);
+                SS_Log::log(print_r($mail->ErrorInfo, true), SS_Log::NOTICE);
             }
             return false;
         }

--- a/code/EmogrifiedSmtpMailer.php
+++ b/code/EmogrifiedSmtpMailer.php
@@ -163,7 +163,10 @@ class EmogrifiedSmtpMailer extends SmtpMailer
         }
         if ($level = $this->getSMTPDebug()) {
             $mail->SMTPDebug = $level;
-            $mail->Debugoutput = 'html';  // HTML friendly report
+            $mail->Debugoutput = function ($str, $level)
+            {
+                SS_Log::log(new Exception(print_r($str, true)), SS_Log::NOTICE);
+            };
         }
 
         // send and return


### PR DESCRIPTION
Currently PHPMailer's SMTP logging is echoed to the screen.  This is no good when there are redirections.  Log via a Silverstripe notice instead.